### PR TITLE
Admin can create and destroy user accounts

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,23 @@
+class UsersController < ApplicationController
+
+  def create
+    user = User.create(user_params)
+    if user.save 
+      redirect_to dashboard_path, :alert => "User created."
+    else
+      redirect_to dashboard_path, :alert => "User was not created."
+    end
+  end 
+
+  def destroy
+    user = User.find(params[:id])
+    user.destroy!
+    redirect_to dashboard_path, :notice => "User deleted."
+  end
+
+  private
+
+  def user_params
+   params.require(:user).permit(:email, :password)
+  end
+end

--- a/app/creators/user_creator.rb
+++ b/app/creators/user_creator.rb
@@ -1,0 +1,10 @@
+class UserCreator
+
+  def initialize(user)
+      User.create(
+        email:         user[:email],
+        password:      user[:password]
+      )
+    end
+  end
+end

--- a/app/presenters/dashboard_presenter.rb
+++ b/app/presenters/dashboard_presenter.rb
@@ -16,6 +16,10 @@ class DashboardPresenter
     Contact.new
   end
 
+  def create_new_user
+    User.new
+  end
+
   def retrieve_stripe_donations
     Donation.stripe_donations.where(date: first_day_of_year..current_day).order(date: :desc)
   end
@@ -26,6 +30,10 @@ class DashboardPresenter
 
   def retrieve_contacts
     Contact.all
+  end
+
+  def retrieve_users 
+    User.where(admin: false)
   end
 
   def retrieve_stripe_subtotal

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -80,6 +80,23 @@
     <% end %>
 </div>
 
+<% if current_user.admin == true %>
+  <div id="user-form">
+    <h3>Create User Account</h3>
+      <%= form_for @presenter.create_new_user do |f| %>
+      <%= f.label :email %>
+      <%= f.text_field :email %>
+      <%= f.label :password %>
+      <%= f.text_field :password %>
+      <%= f.submit %>
+      <% end %>
+  </div>
 
-
-
+  <h1>Users</h1>
+  <% @presenter.retrieve_users.each do |user| %>
+    <ul>
+      <%= user.email %>
+      <%= link_to 'Delete', user_path(user), method: :delete, data: { confirm: 'Are you sure you want to delete this account?' } %> 
+    </ul>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   resources :donations, only: [:create, :destroy]
   resources :contacts, only: [:create, :destroy]
+  resources :users, only: [:create, :destroy]
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -2,5 +2,6 @@ FactoryBot.define do
   factory :user do
     email    { Faker::Internet.email }
     password { Faker::Number.number(10) }
+    admin    { true }
   end
 end

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -8,6 +8,8 @@ describe 'an admin' do
 
     before :each do
       allow_any_instance_of(ApplicationController).to receive(:authenticate_user!).and_return(true)
+      user = create(:user)
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
     end
 
     it 'can see a list of credit donations' do
@@ -135,6 +137,35 @@ describe 'an admin' do
       expect(page).to have_content("Contact deleted.")
       expect(page).to_not have_content(email)
       expect(page).to_not have_content(phone)
+      expect(page).to_not have_content('Delete')
+    end
+
+      it 'can create a user account and delete it' do
+      expect(User.count).to eq(1)
+     
+      email = 'Bob@gmail.com'
+      password = 'password-test'
+   
+      visit dashboard_path
+      
+      within(:css, "div#user-form") do
+        fill_in 'Email', with: email
+        fill_in 'Password', with: password
+      end
+
+      click_on 'Create User'
+      expect(current_path).to eq(dashboard_path)
+      expect(User.count).to eq(2)
+      expect(page).to have_content('Users')
+      expect(page).to have_content('User created.')
+      expect(page).to have_link('Delete')
+
+      click_on 'Delete'
+      expect(current_path).to eq(dashboard_path)
+      expect(User.count).to eq(1)
+      expect(page).to have_content('Users')
+      expect(page).to have_content("User deleted.")
+      expect(page).to_not have_content(email)
       expect(page).to_not have_content('Delete')
     end
   end


### PR DESCRIPTION
* Create Admin functionality-
 - admin can create a user with a generic password
 - user can log in and reset password
 - only admin will see the user accounts on the dashboard
 - all test passing
 - works locally